### PR TITLE
Add secp256k1-jdk mini-presentation

### DIFF
--- a/content/socratic-46.md
+++ b/content/socratic-46.md
@@ -13,6 +13,11 @@ Housekeeping
 - Socratic seminars are best when the moderator can let the conversation flow, so try to keep things concrete and focused.
 - The reading list covers February 25th to March 22nd.
 
+Mini-presentation
+-----------------
+
+- secp256k1-jdk: A modern Java API and implementation of secp256k1 for Java, JDK, and JVM languages. 5 minutes + Q & A.
+
 Chain Weather Report
 --------------------
 


### PR DESCRIPTION
secp256k1-jdk: A modern Java API and implementation of secp256k1 for Java, JDK, and JVM languages. 5 minutes + Q & A.

This is the "non-lightning lightning talk" I have discussed with @wraithm. It should be about 5 minutes plus how ever much time seems appropriate for Q&A discussion. And of course, I'll be happy to continue any discussion later with anyone interested.

I'll provide a link to the GitHub just before the meetup or during the presentation (it's not quite ready yet)
